### PR TITLE
Add Earthly-based builds

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,55 @@
+VERSION 0.6
+FROM ubuntu:20.04
+WORKDIR /build
+
+all:
+        BUILD +pkg
+
+deps:
+        RUN apt-get update && apt-get install -y wget
+
+        # download deps we can't get from normal repos
+        RUN wget https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-145/Ubuntu-20.04-arm8-Packages/librtr-dev_0.8.0_arm64.deb
+        RUN wget https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-145/Ubuntu-20.04-arm8-Packages/librtr0_0.8.0_arm64.deb
+        RUN wget 'https://ci1.netdef.org/artifact/LIBYANG-LIBYANGV2/shared/build-12/Ubuntu-20.04-arm8-Packages/libyang2_2.0.7-1~ubuntu20.04u1_arm64.deb'
+        RUN wget 'https://ci1.netdef.org/artifact/LIBYANG-LIBYANGV2/shared/build-12/Ubuntu-20.04-arm8-Packages/libyang2-dev_2.0.7-1~ubuntu20.04u1_arm64.deb'
+
+        RUN DEBIAN_FRONTEND=noninteractive \
+            apt-get install -y --no-install-recommends \
+                    autoconf automake \
+                    libtool make \
+                    build-essential \
+                    devscripts equivs \
+                    libreadline-dev texinfo \
+                    pkg-config \
+                    libpam0g-dev \
+                    libjson-c-dev \
+                    bison flex \
+                    libc-ares-dev \
+                    python3-dev python3-sphinx \
+                    install-info \
+                    libsnmp-dev \
+                    perl \
+                    libcap-dev \
+                    libelf-dev \
+                    libunwind-dev \
+                    wget \
+                    ./librtr0_0.8.0_arm64.deb \
+                    ./librtr-dev_0.8.0_arm64.deb \
+                    './libyang2_2.0.7-1~ubuntu20.04u1_arm64.deb' \
+                    './libyang2-dev_2.0.7-1~ubuntu20.04u1_arm64.deb'
+        COPY --dir debian ./
+        RUN mk-build-deps --remove debian/control && \
+            DEBIAN_FRONTEND=noninteractive \
+            apt install -y --no-install-recommends \
+            ./frr-build-deps_8.5~dev-1_all.deb
+
+pkg-deb:
+        FROM +deps
+        COPY --dir * .
+        RUN dpkg-buildpackage -b -rfakeroot -us -uc
+        ARG TARGETPLATFORM
+        SAVE ARTIFACT ../*.deb AS LOCAL ./dist/
+
+pkg:
+        BUILD +pkg-deb

--- a/Earthfile
+++ b/Earthfile
@@ -153,6 +153,26 @@ pkg-one:
                cp frr*.tar.gz rpmbuild/SOURCES/.
            RUN rpmbuild \
                --define "_topdir `pwd`/rpmbuild" \
+               --define "with_babeld 0" \
+               --define "with_bfdd 1" \
+               --define "with_bgpvnc 0" \
+               --define "with_cumulus 0" \
+               --define "with_eigrpd 1" \
+               --define "with_fpm 0" \
+               --define "with_ldpd 0" \
+               --define "with_multipath 1" \
+               --define "with_nhrpd 0" \
+               --define "with_ospfapi 1" \
+               --define "with_ospfclient 1" \
+               --define "with_pam 0" \
+               --define "with_pbrd 0" \
+               --define "with_pimd 0" \
+               --define "with_pim6d 0" \
+               --define "with_vrrpd 0" \
+               --define "with_rtadv 0" \
+               --define "with_watchfrr 1" \
+               --define "with_pathd 0" \
+               --define "with_privileged_vty 1" \
                -ba rpmbuild/SPECS/frr.spec
            SAVE ARTIFACT /build/rpmbuild/RPMS/*/*.rpm AS LOCAL \
                 ./dist/${TARGETPLATFORM}/${DISTRO}/${RELEASE}/

--- a/Earthfile
+++ b/Earthfile
@@ -140,6 +140,10 @@ pkg-one:
         ARG TARGETPLATFORM
         FROM +deps-one --DISTRO=${DISTRO} --RELEASE=${RELEASE}
         COPY --dir * .
+        # Append -rv to the frr version
+        # We do this here so that it's easier to apply the rv-specific patches to new releases
+        RUN sed -ri 's/^AC_INIT\(\[frr\], \[(.+)\], /AC_INIT([frr], [\1-rv], /' configure.ac && \
+            grep AC_INIT configure.ac
         IF [ "${DISTRO}" = "centos" ]
            RUN ./bootstrap.sh && \
                ./configure && \

--- a/Earthfile
+++ b/Earthfile
@@ -1,55 +1,117 @@
 VERSION 0.6
-FROM ubuntu:20.04
-WORKDIR /build
+
+ARG DEFAULT_DISTRO=ubuntu
+ARG DEFAULT_RELEASE=22.04
 
 all:
-        BUILD +pkg
+    BUILD +pkg-march --DISTRO=ubuntu --RELEASE=20.04 # focal
+    BUILD +pkg-march --DISTRO=ubuntu --RELEASE=22.04 # jammy
 
-deps:
-        RUN apt-get update && apt-get install -y wget
+    #BUILD +pkg --DISTRO=centos --RELEASE=7
+    #BUILD +pkg --DISTRO=centos --RELEASE=8
 
-        # download deps we can't get from normal repos
-        RUN wget https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-145/Ubuntu-20.04-arm8-Packages/librtr-dev_0.8.0_arm64.deb
-        RUN wget https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-145/Ubuntu-20.04-arm8-Packages/librtr0_0.8.0_arm64.deb
-        RUN wget 'https://ci1.netdef.org/artifact/LIBYANG-LIBYANGV2/shared/build-12/Ubuntu-20.04-arm8-Packages/libyang2_2.0.7-1~ubuntu20.04u1_arm64.deb'
-        RUN wget 'https://ci1.netdef.org/artifact/LIBYANG-LIBYANGV2/shared/build-12/Ubuntu-20.04-arm8-Packages/libyang2-dev_2.0.7-1~ubuntu20.04u1_arm64.deb'
+os-one:
+    ARG --required DISTRO
+    ARG --required RELEASE
+    ARG --required TARGETARCH
+    FROM ${DISTRO}:${RELEASE}
+    WORKDIR /build
 
+    IF [ "${DISTRO}" = "centos" ]
+        IF [ "${RELEASE}" = "8" ]
+            RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+                sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+            RUN dnf install -y dnf-plugins-core
+            RUN dnf config-manager --set-enabled powertools
+            RUN dnf install -y \
+                ca-certificates
+        ELSE
+            RUN yum install -y --setopt=skip_missing_names_on_install=False \
+                ca-certificates
+        END
+    ELSE
         RUN DEBIAN_FRONTEND=noninteractive \
-            apt-get install -y --no-install-recommends \
-                    autoconf automake \
-                    libtool make \
-                    build-essential \
-                    devscripts equivs \
-                    libreadline-dev texinfo \
-                    pkg-config \
-                    libpam0g-dev \
-                    libjson-c-dev \
-                    bison flex \
-                    libc-ares-dev \
-                    python3-dev python3-sphinx \
-                    install-info \
-                    libsnmp-dev \
-                    perl \
-                    libcap-dev \
-                    libelf-dev \
-                    libunwind-dev \
-                    wget \
-                    ./librtr0_0.8.0_arm64.deb \
-                    ./librtr-dev_0.8.0_arm64.deb \
-                    './libyang2_2.0.7-1~ubuntu20.04u1_arm64.deb' \
-                    './libyang2-dev_2.0.7-1~ubuntu20.04u1_arm64.deb'
-        COPY --dir debian ./
-        RUN mk-build-deps --remove debian/control && \
-            DEBIAN_FRONTEND=noninteractive \
-            apt install -y --no-install-recommends \
+            apt-get update && apt-get install -y --no-install-recommends \
+            ca-certificates \
+            wget
+    END
+
+deps-one:
+    ARG --required DISTRO
+    ARG --required RELEASE
+    ARG --required TARGETARCH
+    FROM +os-one --DISTRO=${DISTRO} --RELEASE=${RELEASE}
+
+    RUN DEBIAN_FRONTEND=noninteractive \
+        apt-get install -y --no-install-recommends \
+            autoconf automake \
+            libtool make \
+            build-essential \
+            devscripts equivs \
+            libreadline-dev texinfo \
+            pkg-config \
+            libpam0g-dev \
+            libjson-c-dev \
+            bison flex \
+            libc-ares-dev \
+            python3-dev python3-sphinx \
+            install-info \
+            libsnmp-dev \
+            perl \
+            libcap-dev \
+            libelf-dev \
+            libunwind-dev \
+            wget
+
+    # only "new" releases have libyang and librtr
+    IF [ "${TARGETARCH}" = "arm64" ]
+        ARG frr_arch="arm8"
+    ELSE
+        ARG frr_arch="x86_64"
+    END
+    IF [ "$DISTRO" = "ubuntu" ] && [ "${RELEASE}" = "20.04" ]
+        # libyang
+        ARG yang_base="https://ci1.netdef.org/artifact/LIBYANG-LIBYANGV2/shared/build-12"
+        ARG yang_pkg="${yang_base}/Ubuntu-${RELEASE}-${frr_arch}-Packages"
+        RUN wget "${yang_pkg}/libyang2_2.0.7-1~${DISTRO}${RELEASE}u1_${TARGETARCH}.deb" && \
+            wget "${yang_pkg}/libyang2-dev_2.0.7-1~${DISTRO}${RELEASE}u1_${TARGETARCH}.deb"
+        # librtr
+        ARG rtr_base="https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-00149"
+        ARG rtr_pkg="${rtr_base}/Ubuntu-${RELEASE}-${frr_arch}-Packages"
+        RUN wget "${rtr_pkg}/librtr-dev_0.8.0_${TARGETARCH}.deb" && \
+            wget "${rtr_pkg}/librtr0_0.8.0_${TARGETARCH}.deb"
+        ARG extra_pkgs="./*.deb"
+    ELSE
+        ARG extra_pkgs="libyang2-dev librtr-dev"
+    END
+    RUN DEBIAN_FRONTEND=noninteractive \
+        apt-get install -y --no-install-recommends \
+                ${extra_pkgs}
+
+    COPY --dir debian ./
+    RUN mk-build-deps --remove debian/control && \
+        DEBIAN_FRONTEND=noninteractive \
+        apt install -y --no-install-recommends \
             ./frr-build-deps_8.5~dev-1_all.deb
 
-pkg-deb:
-        FROM +deps
-        COPY --dir * .
-        RUN dpkg-buildpackage -b -rfakeroot -us -uc
+pkg-one:
+        ARG DISTRO=${DEFAULT_DISTRO}
+        ARG RELEASE=${DEFAULT_RELEASE}
         ARG TARGETPLATFORM
-        SAVE ARTIFACT ../*.deb AS LOCAL ./dist/
+        FROM +deps-one --DISTRO=${DISTRO} --RELEASE=${RELEASE}
+        COPY --dir * .
+        IF [ "${DISTRO}" = "centos" ]
+           RUN echo "TODO"
+        ELSE
+           RUN dpkg-buildpackage -b -rfakeroot -us -uc
+           SAVE ARTIFACT ../*.deb AS LOCAL ./dist/${TARGETPLATFORM}/${DISTRO}/${RELEASE}/
+        END
 
-pkg:
-        BUILD +pkg-deb
+pkg-march:
+        ARG --required DISTRO
+        ARG --required RELEASE
+        BUILD \
+              --platform=linux/arm64 \
+              --platform=linux/amd64 \
+              +pkg-one \
+                  --DISTRO=${DISTRO} --RELEASE=${RELEASE}

--- a/Earthfile
+++ b/Earthfile
@@ -23,13 +23,9 @@ os-one:
                 sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
             RUN dnf install -y dnf-plugins-core
             RUN dnf config-manager --set-enabled powertools
-            RUN yum -y install epel-release
-            RUN dnf install -y \
-                ca-certificates
-        ELSE
-            RUN yum install -y --setopt=skip_missing_names_on_install=False \
-                ca-certificates
         END
+        RUN yum install -y --setopt=skip_missing_names_on_install=False \
+                ca-certificates
     ELSE
         RUN DEBIAN_FRONTEND=noninteractive \
             apt-get update && apt-get install -y --no-install-recommends \
@@ -45,7 +41,13 @@ deps-one:
 
     IF [ "${DISTRO}" = "centos" ]
        RUN curl -O https://rpm.frrouting.org/repo/frr-stable-repo-1-0.el7.noarch.rpm && \
-           yum install -y ./frr-stable*
+           yum install -y ./frr-stable* && \
+           yum install -y --setopt=skip_missing_names_on_install=False \
+               librtr-devel libyang2-devel
+
+       RUN yum install -y --setopt=skip_missing_names_on_install=False \
+                epel-release
+
        RUN yum install -y --setopt=skip_missing_names_on_install=False \
            git cmake \
            autoconf automake \
@@ -65,14 +67,12 @@ deps-one:
            libssh libssh-devel \
            libunwind-devel \
            systemd-devel \
-           libyang2-devel \
-           librtr-devel
+           python3 python3-devel python3-sphinx
        IF [ "${RELEASE}" = "7" ]
-          RUN yum install -y --setopt=skip_missing_names_on_install=False \
-              pytest python-devel python-sphinx
+          RUN pip3 install pytest
        ELSE
           RUN yum install -y --setopt=skip_missing_names_on_install=False \
-              python3 python3-pytest python3-devel python3-sphinx
+              python3-pytest
        END
 
     ELSE

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -29,6 +29,7 @@
 %{!?with_rtadv:         %global  with_rtadv         1 }
 %{!?with_watchfrr:      %global  with_watchfrr      1 }
 %{!?with_pathd:         %global  with_pathd         1 }
+%{!?with_privileged_vty: %global with_privileged_vty 1 }
 
 # user and group
 %{!?frr_user:           %global  frr_user           frr }
@@ -419,6 +420,9 @@ routing state through standard SNMP MIBs.
     --enable-pathd \
 %else
     --disable-pathd \
+%endif
+%if %{with_privileged_vty}
+    --enable-privileged-vty \
 %endif
     --enable-snmp
     # end


### PR DESCRIPTION
Currently builds for Ubuntu 20.04, 22.04, Centos 7/8.

1. Install Earthly (https://earthly.dev/get-earthly)
2. Clone this repo (this branch for now; the `rv` branch eventually)
3. `earthly +all`
4. Go get a coffee
5. All packages are in `./dist/`

Results:
```
$ find dist/
dist
dist/linux
dist/linux/amd64
dist/linux/amd64/ubuntu
dist/linux/amd64/ubuntu/20.04
dist/linux/amd64/ubuntu/20.04/frr-doc_8.5~dev-1_all.deb
dist/linux/amd64/ubuntu/20.04/frr_8.5~dev-1_amd64.deb
dist/linux/amd64/ubuntu/20.04/frr-pythontools_8.5~dev-1_all.deb
dist/linux/amd64/ubuntu/20.04/frr-rpki-rtrlib_8.5~dev-1_amd64.deb
dist/linux/amd64/ubuntu/20.04/frr-snmp_8.5~dev-1_amd64.deb
dist/linux/amd64/ubuntu/22.04
dist/linux/amd64/ubuntu/22.04/frr-doc_8.5~dev-1_all.deb
dist/linux/amd64/ubuntu/22.04/frr_8.5~dev-1_amd64.deb
dist/linux/amd64/ubuntu/22.04/frr-pythontools_8.5~dev-1_all.deb
dist/linux/amd64/ubuntu/22.04/frr-rpki-rtrlib_8.5~dev-1_amd64.deb
dist/linux/amd64/ubuntu/22.04/frr-snmp_8.5~dev-1_amd64.deb
dist/linux/amd64/centos
dist/linux/amd64/centos/8
dist/linux/amd64/centos/8/frr-snmp-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-devel-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-rpki-rtrlib-debuginfo-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-contrib-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-rpki-rtrlib-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-debugsource-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-snmp-debuginfo-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-debuginfo-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/8/frr-pythontools-8.5_dev_rv-01.el8.x86_64.rpm
dist/linux/amd64/centos/7
dist/linux/amd64/centos/7/frr-8.5_dev_rv-01.el7.x86_64.rpm
dist/linux/amd64/centos/7/frr-snmp-8.5_dev_rv-01.el7.x86_64.rpm
dist/linux/amd64/centos/7/frr-debuginfo-8.5_dev_rv-01.el7.x86_64.rpm
dist/linux/amd64/centos/7/frr-devel-8.5_dev_rv-01.el7.x86_64.rpm
dist/linux/amd64/centos/7/frr-pythontools-8.5_dev_rv-01.el7.x86_64.rpm
dist/linux/amd64/centos/7/frr-rpki-rtrlib-8.5_dev_rv-01.el7.x86_64.rpm
dist/linux/amd64/centos/7/frr-contrib-8.5_dev_rv-01.el7.x86_64.rpm
```
